### PR TITLE
Update treenodelocator.js

### DIFF
--- a/public/js/pimcore/treenodelocator.js
+++ b/public/js/pimcore/treenodelocator.js
@@ -154,7 +154,7 @@ pimcore.treenodelocator = function()
             var locateConfig = globalState.locateConfigs[globalState.currentTreeIndex];
             var tree = locateConfig.tree;
             var rootNode = tree.tree.getRootNode();
-            var rootNodeId = rootNode.getId();
+            var rootNodeId = rootNode.getId().toString();
 
             // Tree root may be shifted to a subnode and the item to be shown
             // is out of tree scope - don't continue if this is the case:


### PR DESCRIPTION
since globalState.pathIds is an array of strings, to compare it, rootNodeId has to be string too. Otherwise index wont be found. Tested in Chrome 131.0.6778.108